### PR TITLE
web: add depoyment to values and group variables underneath

### DIFF
--- a/web/templates/deployment.yaml
+++ b/web/templates/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     heritage: {{ .Release.Service }}
     version: {{ .Values.appVersion }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.deployment.replicaCount }}
   selector:
     matchLabels:
       app: {{ template "web.name" . }}
@@ -22,25 +22,31 @@ spec:
         release: {{ .Release.Name }}
         version: {{ .Values.appVersion }}
     spec:
+{{- if .Values.deployment.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range $pullSecret := .Values.deployment.image.pullSecrets }}
+        - name: {{ $pullSecret }}
+      {{- end }}
+{{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag }}"
+          imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
           ports:
             - name: http
               containerPort: {{ .Values.service.targetPort | default 8080 }}
               protocol: TCP
-{{- if and (.Values.liveness) (.Values.liveness.enabled) }}
+{{- if and (.Values.deployment.liveness) (.Values.deployment.liveness.enabled) }}
           livenessProbe:
             httpGet:
-              path: {{ .Values.liveness.path | default "/" }}
-              port: {{ .Values.liveness.port | default 8080 }}
+              path: {{ .Values.deployment.liveness.path | default "/" }}
+              port: {{ .Values.deployment.liveness.port | default 8080 }}
 {{- end }}
-{{- if and (.Values.readiness) (.Values.readiness.enabled) }}
+{{- if and (.Values.deployment.readiness) (.Values.deployment.readiness.enabled) }}
           readinessProbe:
             httpGet:
-              path: {{ .Values.readiness.path | default "/" }}
-              port: {{ .Values.readiness.port | default 8080 }}
+              path: {{ .Values.deployment.readiness.path | default "/" }}
+              port: {{ .Values.deployment.readiness.port | default 8080 }}
 {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}

--- a/web/templates/service.yaml
+++ b/web/templates/service.yaml
@@ -10,10 +10,10 @@ metadata:
     heritage: {{ .Release.Service }}
     version: {{ .Values.appVersion }}
 spec:
-  type: {{ .Values.service.type }}
+  type: {{ .Values.deployment.service.type }}
   ports:
-    - port: {{ .Values.service.port }}
-      targetPort: {{ .Values.service.targetPort | default "http" }}
+    - port: {{ .Values.deployment.service.port }}
+      targetPort: {{ .Values.deployment.service.targetPort | default "http" }}
       protocol: TCP
       name: http
   selector:

--- a/web/values.yaml
+++ b/web/values.yaml
@@ -2,34 +2,33 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
-
 name: ""
+app: ""
 appVersion: v1
 
+deployment:
+  image:
+    repository: ""
+    tag: ""
+    pullPolicy: IfNotPresent
+    # pullSecrets:
+    #   - secret1
+    #   - secret2
 
-image:
-  repository: ""
-  tag: ""
-  pullPolicy: IfNotPresent
-  # pullSecrets:
-  #   - secret1
-  #   - secret2
+  replicaCount: 1
 
-environment: {}
-secrets: {}
+  liveness:
+    port: 8080
+    enabled: true
 
-liveness:
-  port: 8080
-  enabled: true
-readiness:
-  port: 8080
-  enabled: true
+  readiness:
+    port: 8080
+    enabled: true
 
-service:
-  type: ClusterIP
-  port: 80
-  targetPort: 8080
+  service:
+    type: ClusterIP
+    port: 80
+    targetPort: 8080
 
 ingress:
   enabled: false
@@ -43,6 +42,9 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+
+environment: {}
+secrets: {}
 
 istio:
   enabled: false


### PR DESCRIPTION
Current chart not compatible with Jenkins deploy configuration. Missing `pullSecrets` and `deployment:` block.

