### PR TITLE
Allow to link in services not deployed by this chart

### DIFF
--- a/web/templates/ingress.yaml
+++ b/web/templates/ingress.yaml
@@ -35,5 +35,13 @@ spec:
             backend:
               serviceName: {{ $name }}
               servicePort: http
+  {{- if $.Values.ingress.extraServices }}
+     {{- range $.Values.ingress.extraServices.paths }}
+          - path: {{ .path }}
+            backend:
+              serviceName: {{ .backend.serviceName }}
+              servicePort: {{ .backend.servicePort }}
+     {{- end }}  
+  {{- end }}       
   {{- end }}
 {{- end }}

--- a/web/values.yaml
+++ b/web/values.yaml
@@ -72,7 +72,12 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
-
+  extraServices: {}
+  #  paths:
+  #    - path: /api
+  #      backend:
+  #        serviceName: some-other-backend
+  #        servicePort: 81
 istio:
   enabled: false
   ingress:


### PR DESCRIPTION
Sometimes we want to link in services to the ingress not deployed by this chart.