### PR TITLE
Feature/multi port golang

### DIFF
--- a/golang/Chart.yaml
+++ b/golang/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: golan Helm Chart
 name: golang
-version: 8.0.7
+version: 8.1.0

--- a/golang/Chart.yaml
+++ b/golang/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: golan Helm Chart
 name: golang
-version: 8.1.0
+version: 9.0.0

--- a/golang/templates/deployment.yaml
+++ b/golang/templates/deployment.yaml
@@ -48,9 +48,11 @@ spec:
           {{- end }}
           {{- end }}
           ports:
-            - name: http
-              containerPort: {{ .Values.service.targetPort | default 8080 }}
-              protocol: TCP
+          {{- range .Values.service.ports }}
+          - name: {{ .name }}
+            containerPort: {{ .targetPort }}
+            protocol: TCP
+          {{- end}}
 {{- if and (.Values.liveness) (.Values.liveness.enabled) }}
           livenessProbe:
             httpGet:

--- a/golang/templates/service.yaml
+++ b/golang/templates/service.yaml
@@ -12,10 +12,12 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: {{ .Values.service.port }}
-      targetPort: {{ .Values.service.targetPort | default "http" }}
-      protocol: TCP
-      name: http
+  {{- range .Values.service.ports }}
+  - name: {{ .name }}
+    port: {{ .port }}
+    protocol: TCP
+    targetPort: {{ .targetPort }}
+  {{- end}}
   selector:
     app: {{ template "golang.name" . }}
     release: {{ .Release.Name }}

--- a/golang/values.yaml
+++ b/golang/values.yaml
@@ -54,8 +54,15 @@ readiness:
 
 service:
   type: ClusterIP
-  port: 80
-  targetPort: 8080
+  ports:
+  - port: 
+    name: http
+    port: 80
+    targetPort: 8080
+  - port:
+    name: grpc
+    port: 8081
+    targetPort: 8081
 
 ingress:
   enabled: false


### PR DESCRIPTION
With tow ports we can use http on livenessProbe and grpc to run on a different port. No need to create a local grpc client in order to do livenessProbe. 