### PR TITLE
golang: add support for custom name on service port

### DIFF
--- a/golang/Chart.yaml
+++ b/golang/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: golan Helm Chart
 name: golang
-version: 8.0.7
+version: 8.0.8

--- a/golang/templates/service.yaml
+++ b/golang/templates/service.yaml
@@ -15,7 +15,7 @@ spec:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.targetPort | default "http" }}
       protocol: TCP
-      name: http
+      name: {{ .Values.service.name | default "http" }}
   selector:
     app: {{ template "golang.name" . }}
     release: {{ .Release.Name }}

--- a/golang/values.yaml
+++ b/golang/values.yaml
@@ -55,7 +55,8 @@ readiness:
 service:
   type: ClusterIP
   port: 80
-  targetPort: 8080
+  targetPort: 8081
+  name: http
 
 ingress:
   enabled: false

--- a/golang/values.yaml
+++ b/golang/values.yaml
@@ -55,7 +55,7 @@ readiness:
 service:
   type: ClusterIP
   port: 80
-  targetPort: 8081
+  targetPort: 8080
   name: http
 
 ingress:


### PR DESCRIPTION
When using grpc services and istio it seem that the request is not passed correct from the proxy pod to the golang pod when the service port name is http. When we change the name to something different than http it works fine. (i.e. grpc).

 