### PR TITLE
Add Kiali Operator to official ACE charts

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,6 +10,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+      with:
+        submodules: recursive
     - name: Helm Install
       run: |
         curl -sSL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz \
@@ -32,6 +34,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+      with:
+        submodules: recursive
     - name: Helm Install
       run: |
         curl -sSL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz \

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "kiali-operator"]
+	path = kiali-operator
+	url = https://github.com/evry-ace/helm-kiali-operator.git


### PR DESCRIPTION
Test and publish the Kiali Operator helm chart from https://github.com/evry-ace/helm-kiali-operator