### PR TITLE
Use Personal Access Token for pushing charts

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -53,7 +53,7 @@ jobs:
       with:
         ref: gh-pages
         path: ./release
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.GITHUB_PAT }}
     - name: Helm Publish
       run: |
         ls -la ${HELM_TMP_DIR}


### PR DESCRIPTION
Related issues:

https://github.com/JamesIves/github-pages-deploy-action/issues/5
https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/m-p/31266/highlight/true#M743