### PR TITLE
Add Pod AntiAffinity configurations

### DIFF
--- a/dotnet/Chart.yaml
+++ b/dotnet/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: .NET Core Helm Chart
 name: dotnet
-version: 7.1.3
+version: 7.2.0
 

--- a/dotnet/templates/deployment.yaml
+++ b/dotnet/templates/deployment.yaml
@@ -88,8 +88,28 @@ spec:
     {{- end }}
     {{- with .Values.affinity }}
       affinity:
-{{ toYaml . | indent 8 }}
+      {{- with .Values.affinity }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if eq .Values.podAntiAffinity "hard" }}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: "{{ .Values.podAntiAffinityTopologyKey }}"
+              labelSelector:
+                matchLabels:
+                  {{- include "dotnet.selectorLabels" . | nindent 18 }}
+      {{- else if eq .Values.podAntiAffinity "soft" }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: "{{ .Values.podAntiAffinityTopologyKey }}"
+                labelSelector:
+                  matchLabels:
+                    {{- include "dotnet.selectorLabels" . | nindent 20 }}
+      {{- end }}
     {{- end }}
+
     {{- with .Values.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}

--- a/dotnet/templates/deployment.yaml
+++ b/dotnet/templates/deployment.yaml
@@ -86,7 +86,8 @@ spec:
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.affinity }}
+
+    {{- if or .Values.affinity .Values.podAntiAffinity }}
       affinity:
       {{- with .Values.affinity }}
         {{- toYaml . | nindent 8 }}

--- a/dotnet/values.yaml
+++ b/dotnet/values.yaml
@@ -111,13 +111,16 @@ nodeSelector: {}
 
 tolerations: []
 
-affinity: {}
-
 ## Pod affinity
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 ##
 podAntiAffinity: soft
 podAntiAffinityTopologyKey: "kubernetes.io/hostname"
+
+## Custom Affinity settings
+## Defining 'affinity' will disable any podAntiAffinity settings.
+## If you still need anti-affinity, you must include the configuration here.
+affinity: {}
 
 # We need to set targetPort (Where metrics are hosted) so that it can be collected on the outside of the SMESH
 metrics:

--- a/dotnet/values.yaml
+++ b/dotnet/values.yaml
@@ -113,6 +113,12 @@ tolerations: []
 
 affinity: {}
 
+## Pod affinity
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+##
+podAntiAffinity: soft
+podAntiAffinityTopologyKey: "kubernetes.io/hostname"
+
 # We need to set targetPort (Where metrics are hosted) so that it can be collected on the outside of the SMESH
 metrics:
   enabled: true

--- a/golang/Chart.yaml
+++ b/golang/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: golan Helm Chart
 name: golang
-version: 11.1.3
+version: 11.2.0

--- a/golang/templates/deployment.yaml
+++ b/golang/templates/deployment.yaml
@@ -98,8 +98,7 @@ spec:
             - topologyKey: "{{ .Values.podAntiAffinityTopologyKey }}"
               labelSelector:
                 matchLabels:
-                  app: {{ template "golang.name" . }}
-                  release: {{ .Release.Name }}
+                  {{- include "golang.selectorLabels" . | nindent 18 }}
       {{- else if eq .Values.podAntiAffinity "soft" }}
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -108,8 +107,7 @@ spec:
                 topologyKey: "{{ .Values.podAntiAffinityTopologyKey }}"
                 labelSelector:
                   matchLabels:
-                    app: {{ template "golang.name" . }}
-                    release: {{ .Release.Name }}
+                    {{- include "golang.selectorLabels" . | nindent 20 }}
       {{- end }}
     {{- end }}
 

--- a/golang/templates/deployment.yaml
+++ b/golang/templates/deployment.yaml
@@ -86,10 +86,33 @@ spec:
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.affinity }}
+
+    {{- if or .Values.affinity .Values.podAntiAffinity }}
       affinity:
-{{ toYaml . | indent 8 }}
+      {{- with .Values.affinity }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if eq .Values.podAntiAffinity "hard" }}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: "{{ .Values.podAntiAffinityTopologyKey }}"
+              labelSelector:
+                matchLabels:
+                  app: {{ template "golang.name" . }}
+                  release: {{ .Release.Name }}
+      {{- else if eq .Values.podAntiAffinity "soft" }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: "{{ .Values.podAntiAffinityTopologyKey }}"
+                labelSelector:
+                  matchLabels:
+                    app: {{ template "golang.name" . }}
+                    release: {{ .Release.Name }}
+      {{- end }}
     {{- end }}
+
     {{- with .Values.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}

--- a/golang/values.yaml
+++ b/golang/values.yaml
@@ -111,6 +111,15 @@ nodeSelector: {}
 
 tolerations: []
 
+## Pod affinity
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+##
+podAntiAffinity: soft
+podAntiAffinityTopologyKey: "kubernetes.io/hostname"
+
+## Custom Affinity settings
+## Defining 'affinity' will disable any podAntiAffinity settings.
+## If you still need anti-affinity, you must include the configuration here.
 affinity: {}
 
 # We need to set targetPort (Where metrics are hosted) so that it can be collected on the outside of the SMESH

--- a/java/Chart.yaml
+++ b/java/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Java Helm Chart
 name: java
-version: 4.3.4
+version: 4.4.0

--- a/java/templates/deployment.yaml
+++ b/java/templates/deployment.yaml
@@ -90,10 +90,30 @@ spec:
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.affinity }}
+    {{- if or .Values.affinity .Values.podAntiAffinity }}
       affinity:
-{{ toYaml . | indent 8 }}
+      {{- with .Values.affinity }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if eq .Values.podAntiAffinity "hard" }}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: "{{ .Values.podAntiAffinityTopologyKey }}"
+              labelSelector:
+                matchLabels:
+                  {{- include "java.selectorLabels" . | nindent 18 }}
+      {{- else if eq .Values.podAntiAffinity "soft" }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: "{{ .Values.podAntiAffinityTopologyKey }}"
+                labelSelector:
+                  matchLabels:
+                    {{- include "java.selectorLabels" . | nindent 20 }}
+      {{- end }}
     {{- end }}
+
     {{- with .Values.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}

--- a/java/values.yaml
+++ b/java/values.yaml
@@ -122,6 +122,9 @@ tolerations: []
 podAntiAffinity: soft
 podAntiAffinityTopologyKey: "kubernetes.io/hostname"
 
+## Custom Affinity settings
+## Defining 'affinity' will disable any podAntiAffinity settings.
+## If you still need anti-affinity, you must include the configuration here.
 affinity: {}
 
 # We need to set targetPort (Where metrics are hosted) so that it can be collected on the outside of the SMESH

--- a/java/values.yaml
+++ b/java/values.yaml
@@ -116,6 +116,12 @@ nodeSelector: {}
 
 tolerations: []
 
+## Pod affinity
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+##
+podAntiAffinity: soft
+podAntiAffinityTopologyKey: "kubernetes.io/hostname"
+
 affinity: {}
 
 # We need to set targetPort (Where metrics are hosted) so that it can be collected on the outside of the SMESH

--- a/nodejs/Chart.yaml
+++ b/nodejs/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Node.js Helm Chart
 name: nodejs
-version: 11.1.3
+version: 11.2.0

--- a/nodejs/templates/deployment.yaml
+++ b/nodejs/templates/deployment.yaml
@@ -86,7 +86,8 @@ spec:
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.affinity }}
+    
+    {{- if or .Values.affinity .Values.podAntiAffinity }}
       affinity:
       {{- with .Values.affinity }}
         {{- toYaml . | nindent 8 }}

--- a/nodejs/templates/deployment.yaml
+++ b/nodejs/templates/deployment.yaml
@@ -88,8 +88,28 @@ spec:
     {{- end }}
     {{- with .Values.affinity }}
       affinity:
-{{ toYaml . | indent 8 }}
+      {{- with .Values.affinity }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if eq .Values.podAntiAffinity "hard" }}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: "{{ .Values.podAntiAffinityTopologyKey }}"
+              labelSelector:
+                matchLabels:
+                  {{- include "nodejs.selectorLabels" . | nindent 18 }}
+      {{- else if eq .Values.podAntiAffinity "soft" }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: "{{ .Values.podAntiAffinityTopologyKey }}"
+                labelSelector:
+                  matchLabels:
+                    {{- include "nodejs.selectorLabels" . | nindent 20 }}
+      {{- end }}
     {{- end }}
+
     {{- with .Values.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}

--- a/nodejs/values.yaml
+++ b/nodejs/values.yaml
@@ -116,6 +116,11 @@ tolerations: []
 podAntiAffinity: soft
 podAntiAffinityTopologyKey: "kubernetes.io/hostname"
 
+## Custom Affinity settings
+## Defining 'affinity' will disable any podAntiAffinity settings.
+## If you still need anti-affinity, you must include the configuration here.
+affinity: {}
+
 # We need to set targetPort (Where metrics are hosted) so that it can be collected on the outside of the SMESH
 metrics:
   enabled: true

--- a/nodejs/values.yaml
+++ b/nodejs/values.yaml
@@ -110,7 +110,11 @@ nodeSelector: {}
 
 tolerations: []
 
-affinity: {}
+## Pod affinity
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+##
+podAntiAffinity: soft
+podAntiAffinityTopologyKey: "kubernetes.io/hostname"
 
 # We need to set targetPort (Where metrics are hosted) so that it can be collected on the outside of the SMESH
 metrics:

--- a/web/Chart.yaml
+++ b/web/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Helm chart for deployment of web servers
 name: web
-version: 8.1.3
+version: 8.2.0

--- a/web/templates/deployment.yaml
+++ b/web/templates/deployment.yaml
@@ -81,10 +81,31 @@ spec:
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.affinity }}
+
+    {{- if or .Values.affinity .Values.podAntiAffinity }}
       affinity:
-{{ toYaml . | indent 8 }}
+      {{- with .Values.affinity }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if eq .Values.podAntiAffinity "hard" }}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: "{{ .Values.podAntiAffinityTopologyKey }}"
+              labelSelector:
+                matchLabels:
+                  {{- include "web.selectorLabels" . | nindent 18 }}
+      {{- else if eq .Values.podAntiAffinity "soft" }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: "{{ .Values.podAntiAffinityTopologyKey }}"
+                labelSelector:
+                  matchLabels:
+                    {{- include "web.selectorLabels" . | nindent 20 }}
+      {{- end }}
     {{- end }}
+
     {{- with .Values.tolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}

--- a/web/values.yaml
+++ b/web/values.yaml
@@ -116,6 +116,15 @@ nodeSelector: {}
 
 tolerations: []
 
+## Pod affinity
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+##
+podAntiAffinity: soft
+podAntiAffinityTopologyKey: "kubernetes.io/hostname"
+
+## Custom Affinity settings
+## Defining 'affinity' will disable any podAntiAffinity settings.
+## If you still need anti-affinity, you must include the configuration here.
 affinity: {}
 
 # We need to set targetPort (Where metrics are hosted) so that it can be collected on the outside of the SMESH


### PR DESCRIPTION
Prevent pods form being scheduled on the same machine in order to prevent
downtime.

Charts:
* [x] golang
* [x] java
* [x] dotnet
* [x] nodejs
* [x] web