### PR TITLE
Remove default args and command setting from cronjob values.yaml

### DIFF
--- a/cronjob/Chart.yaml
+++ b/cronjob/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Cron job helm chart
 name: cronjob
-version: 1.0.0
+version: 1.0.1
 

--- a/cronjob/values.yaml
+++ b/cronjob/values.yaml
@@ -9,11 +9,11 @@ job:
   concurrencyPolicy: Forbid  #  Allow (default): The cron job allows concurrently running jobs
                              #  Forbid: The cron job does not allow concurrent runs; if it is time for a new job run and the previous job run hasn't finished yet, the cron job skips the new job run
                              #  Replace: If it is time for a new job run and the previous job run hasn't finished yet, the cron job replaces the currently running job run with a new job run
-  args:
-    - /bin/sh
-    - -c
-    - date; echo Hello from the Kubernetes cluster
-  command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"] 
+#  args:                     #  optional to add args to cron job
+#    - /bin/sh               #  can add an array of args to cron job 
+#    - -c
+#    - date; echo Hello from the Kubernetes cluster
+#  command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"] # optional command to pass to container
 
 image:
   repository: ""


### PR DESCRIPTION
Remove default values from values.yaml file in chart. 

When these values are set in values.yaml they are by default added to the helm deployment. 

If you need to create a cronjob without  `args` and/or without `command` values this PR will make it possible. 