### PR TITLE
Add support for istio and hashicorp vault in cronjob helm template

### DIFF
--- a/cronjob/Chart.yaml
+++ b/cronjob/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Cron job helm chart
 name: cronjob
-version: 1.0.1
+version: 1.1.1
 

--- a/cronjob/README.md
+++ b/cronjob/README.md
@@ -1,0 +1,23 @@
+# Cron job chart
+
+The cron job chart can be used to run cron jobs in kubernetes.
+
+The chart supports istio service mesh. In order to complete a job in a istio service mesh the envoy proxy needs to be stoped by the container running the job.
+
+The recommended way to ensure a job running with istio is to do two checks:
+
+Check to see if the envoy proxy is up and running BEFORE the job starts.
+
+Endpoint to check status:
+
+```.shell
+http://127.0.0.1:15000/server_info
+```
+
+Terminate the envoy proxy AFTER the job finish.
+
+Endpoint to quit envoy proxy:
+
+```.shell
+http://127.0.0.1:15000/quitquitquit
+```

--- a/cronjob/templates/cronjob.yaml
+++ b/cronjob/templates/cronjob.yaml
@@ -13,46 +13,31 @@ spec:
   {{- end}}
   schedule: {{ .Values.job.schedule | quote }}
   jobTemplate:
+    metadata:
+      labels:
+        {{- include "cronjob.metaLabels" . | nindent 8 }}
     spec:
       template:
+        metadata:
+        {{- if .Values.podAnnotations }}
+          annotations:
+          {{ toYaml .Values.podAnnotations | indent 4 }}
+        {{- end }}
+          labels:
+            {{- include "cronjob.metaLabels" . | nindent 12 }}
+            {{- if .Values.istio.enabled }}
+            security.istio.io/tlsMode: istio
+            service.istio.io/canonical-name: "{{ .Release.Name }}-{{ .Values.job.name }}"
+            service.istio.io/canonical-revision: v1
+            {{- end }}
         spec:
           containers:
-          - name: "{{ .Release.Name }}-{{ .Values.job.name }}"
-            image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-            imagePullPolicy: Always
-            {{- if .Values.image.pullSecrets }}
-            imagePullSecrets:
-            {{- range $pullSecret := .Values.image.pullSecrets }}
-              - name: {{ $pullSecret }}
-              {{- end }}
-            {{- end }}
-            {{- if or (.Values.volumeMounts) (.Values.csi) }}
-            volumeMounts:
-            {{- if .Values.volumeMounts }}
-            {{ toYaml .Values.volumeMounts | indent 12 }}
-            {{- end }}
-            {{- if .Values.csi }}
-              - name: {{ .Values.csi.name }}
-                mountPath: {{ .Values.csi.mountPath | quote }}
-                readOnly: true
-            {{- end }}
-            {{- end }}
-            {{- if .Values.job.args }}
-            args:
-              {{- range $arg := .Values.job.args }}
-              - {{ $arg }}
-              {{- end }}
-            {{- end }}
-            {{- if .Values.job.command }}
-            command: {{ .Values.job.command }}
-            {{- end }}
-            env:
+            - name: "{{ .Release.Name }}-{{ .Values.job.name }}"
+              env:
               - name: APP_ENV
                 value: {{ .Values.appEnv }}
-              {{- if .Values.secrets }}
-              {{ toYaml .Values.secrets | indent 10 }}
-              {{- end }}
-              {{- if .Values.environment }}
-              {{ toYaml .Values.environment | indent 10 }}
-              {{- end }}
-          restartPolicy: OnFailure
+            {{-  if .Values.environment }}
+{{ toYaml .Values.environment | indent 14 }}
+            {{- end}}
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              imagePullPolicy: Always

--- a/cronjob/values.yaml
+++ b/cronjob/values.yaml
@@ -22,3 +22,14 @@ image:
   #   - secret1
   #   - secret2
 
+podAnnotations: {}
+
+podLabels: {} 
+  
+environment: {}
+
+istio:
+  enabled: false
+  tlsMode: "istio"
+  revision: "v1"
+


### PR DESCRIPTION
The following changes are added to support deployment of cronjob in a istio service mesh.

* Add podannotations to support hashicorp vault secret injection
* Add istio lables to enable connection to services inside service mesh. 
* Change to apply environment variables to be applied to the container running the job.
* Update version from 1.0.1 to 1.1.1 major change. 