### PR TITLE
web: move flux image variable to root scope

### DIFF
--- a/web/Chart.yaml
+++ b/web/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Helm chart for deployment of web servers
 name: web
-version: 9.1.1
+version: 9.1.2

--- a/web/templates/deployment.yaml
+++ b/web/templates/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     metadata:
       labels:
         {{- include "web.metaLabels" . | nindent 8 }}
-        {{- if .Values.podLabels }}        
+        {{- if .Values.podLabels }}
         {{ toYaml .Values.podLabels | nindent 8 }}
         {{- end -}}
 {{- if .Values.podAnnotations }}
@@ -26,18 +26,20 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
     spec:
+{{- if not (typeIs "string" .Values.image) }}
 {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
       {{- range $pullSecret := .Values.image.pullSecrets }}
         - name: {{ $pullSecret }}
       {{- end }}
 {{- end }}
+{{- end }}
       securityContext:
 {{ toYaml .Values.securityContext | indent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          {{- if .Values.image.image }}
-          image: "{{ .Values.image.image }}"
+          {{- if typeIs "string" .Values.image }}
+          image: "{{ .Values.image }}"
           {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           {{- end }}

--- a/web/values.yaml
+++ b/web/values.yaml
@@ -7,9 +7,10 @@ replicaCount: 1
 name: ""
 appVersion: v1
 
+
+# Full image repository with tag, needed for Flux automation
+# image: "my.repo.io/my/image:my-tag"
 image:
-  # Full image repository with tag, usefull for Flux automation
-  # image: ""
   repository: ""
   tag: ""
   # pullSecrets:
@@ -24,7 +25,7 @@ podDisruptionBudget: {}
 
 securityContext:
   runAsNonRoot: true
-  
+
 environment: {}
 #  - name: APP_ENV
 #    value: "production"


### PR DESCRIPTION
`image.image` is not a supported variable in Flux, this pull requests allows `image` to be a string to solve this.