### PR TITLE
Add restartPolicy on cron job template spec

### DIFF
--- a/cronjob/Chart.yaml
+++ b/cronjob/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Cron job helm chart
 name: cronjob
-version: 1.1.1
+version: 1.1.2
 

--- a/cronjob/templates/cronjob.yaml
+++ b/cronjob/templates/cronjob.yaml
@@ -31,6 +31,7 @@ spec:
             service.istio.io/canonical-revision: v1
             {{- end }}
         spec:
+          restartPolicy: {{ .Values.job.restartPolicy | default "Never" }}
           containers:
             - name: "{{ .Release.Name }}-{{ .Values.job.name }}"
               env:

--- a/cronjob/values.yaml
+++ b/cronjob/values.yaml
@@ -14,6 +14,9 @@ job:
 #    - -c
 #    - date; echo Hello from the Kubernetes cluster
 #  command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"] # optional command to pass to container
+#  restartPolicy: onFailure
+#                 only OnFailure or Never  
+#                 https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-template
 
 image:
   repository: ""


### PR DESCRIPTION
Default restartPolicy on pods are Always. This is not allowed for job spec

https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-template