### PR TITLE
Change pdb api version to v1 

### DIFF
--- a/dotnet/Chart.yaml
+++ b/dotnet/Chart.yaml
@@ -4,5 +4,5 @@ name: dotnet
 version: 11.0.1
 dependencies:
   - name: libchart
-    version: 2.0.2
+    version: 3.0.0
     repository: file://../libchart

--- a/golang/Chart.yaml
+++ b/golang/Chart.yaml
@@ -4,5 +4,5 @@ name: golang
 version: 15.0.1
 dependencies:
   - name: libchart
-    version: 2.0.2
+    version: 3.0.0
     repository: file://../libchart

--- a/java/Chart.yaml
+++ b/java/Chart.yaml
@@ -4,5 +4,5 @@ name: java
 version: 8.0.2
 dependencies:
   - name: libchart
-    version: 2.0.2
+    version: 3.0.0
     repository: file://../libchart

--- a/libchart/Chart.yaml
+++ b/libchart/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.2
+version: 3.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/libchart/templates/_pdb.tpl
+++ b/libchart/templates/_pdb.tpl
@@ -1,6 +1,6 @@
 {{- define "libchart.pdb.tpl" -}}
 {{- if .Values.podDisruptionBudget -}}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "libchart.name" . }}

--- a/nodejs/Chart.yaml
+++ b/nodejs/Chart.yaml
@@ -4,5 +4,5 @@ name: nodejs
 version: 15.0.1
 dependencies:
   - name: libchart
-    version: 2.0.2
+    version: 3.0.0
     repository: file://../libchart

--- a/web/Chart.yaml
+++ b/web/Chart.yaml
@@ -5,5 +5,5 @@ name: web
 version: 12.0.1
 dependencies:
   - name: libchart
-    version: 2.0.2
+    version: 3.0.0
     repository: file://../libchart


### PR DESCRIPTION


## Description

PDB API version policy/v1beta1 is deprecated in Kubernetes v1.21.0 and deleted in v1.25.0. 
Replacement is policy/v1

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have made design choices.
- [ ] My design choices are documented in an Architecture Decision Record in the designated ARD folder of this repo.

## Issues this PR fixes
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

